### PR TITLE
Unittest upgrade_gitlab

### DIFF
--- a/lib/libgitlab.py
+++ b/lib/libgitlab.py
@@ -394,13 +394,14 @@ class GitlabHelper:
         hookenv.log("Processing pending package upgrades for GitLab")
         # loop until we're at the right version, stepping through major versions as needed
         # we'll also run reconfigure at each step of the upgrade, to make sure migrations are run
+        major_upgrade = False
         while True:
             package = self.fetch_gitlab_apt_package()
             installed_version = self.get_installed_version(package)
             if package and installed_version:
                 latest_version = self.get_latest_version(package)
-                if 'version' in self and self.version:
-                    desired_version = self.version
+                if self.charm_config["version"]:
+                    desired_version = self.charm_config["version"]
                 else:
                     desired_version = latest_version
                 desired_major = self.get_major_version(desired_version)
@@ -412,6 +413,10 @@ class GitlabHelper:
                             desired_version
                         )
                     )
+                    if major_upgrade:
+                        # Return True if we have been through a major upgrade
+                        # already
+                        return True
                     return False
                 elif desired_major == installed_major:
                     hookenv.log(
@@ -440,6 +445,7 @@ class GitlabHelper:
                     )
                     self.upgrade_package("{}.*".format(next_major))
                     self.gitlab_reconfigure_run()
+                    major_upgrade = True
                     # we will loop here by default, to finish up the next upgrade steps
                     # looping means that we will only get into more complex checking in this
                     # branch of the logic if necessary, if we are already able to do a simple

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,6 +61,7 @@ def mock_charm_dir(monkeypatch):
 
 @pytest.fixture
 def mock_get_installed_version(monkeypatch):
+    """Mock the installed version."""
     installed_version = mock.Mock()
     installed_version.return_value = "1.1.1"
     monkeypatch.setattr(
@@ -70,6 +71,7 @@ def mock_get_installed_version(monkeypatch):
 
 @pytest.fixture
 def mock_get_latest_version(monkeypatch):
+    """Mock get_latest_version."""
     latest_version = mock.Mock()
     latest_version.return_value = "1.1.1"
     monkeypatch.setattr("libgitlab.GitlabHelper.get_latest_version", latest_version)
@@ -79,8 +81,10 @@ def mock_get_latest_version(monkeypatch):
 def mock_upgrade_package(
     mock_get_installed_version, mock_get_latest_version, monkeypatch
 ):
-    """ Mock the upgrade_package function and set the installed versions. When a
-    wildcard is provided the minor and patch are set to 1"""
+    """Mock the upgrade_package function and set the installed versions.
+
+    When a wildcard is provided the minor and patch are set to 1
+    """
     def mock_upgrade(self, version=None):
         if version:
             sane_version = version.replace("*", "1.1")
@@ -93,6 +97,7 @@ def mock_upgrade_package(
 
 @pytest.fixture
 def mock_gitlab_hookenv_log(monkeypatch):
+    """Mock hookenv.log."""
     mock_log = mock.Mock()
     monkeypatch.setattr("libgitlab.hookenv.log", mock_log)
     return mock_log

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -60,7 +60,48 @@ def mock_charm_dir(monkeypatch):
 
 
 @pytest.fixture
-def libgitlab(tmpdir, mock_hookenv_config, mock_charm_dir, monkeypatch):
+def mock_get_installed_version(monkeypatch):
+    installed_version = mock.Mock()
+    installed_version.return_value = "1.1.1"
+    monkeypatch.setattr(
+        "libgitlab.GitlabHelper.get_installed_version", installed_version
+    )
+
+
+@pytest.fixture
+def mock_get_latest_version(monkeypatch):
+    latest_version = mock.Mock()
+    latest_version.return_value = "1.1.1"
+    monkeypatch.setattr("libgitlab.GitlabHelper.get_latest_version", latest_version)
+
+
+@pytest.fixture
+def mock_upgrade_package(
+    mock_get_installed_version, mock_get_latest_version, monkeypatch
+):
+    """ Mock the upgrade_package function and set the installed versions. When a
+    wildcard is provided the minor and patch are set to 1"""
+    def mock_upgrade(self, version=None):
+        if version:
+            sane_version = version.replace("*", "1.1")
+            self.get_installed_version.return_value = sane_version
+        else:
+            self.get_installed_version.return_value = self.get_latest_version()
+
+    monkeypatch.setattr("libgitlab.GitlabHelper.upgrade_package", mock_upgrade)
+
+
+@pytest.fixture
+def mock_gitlab_hookenv_log(monkeypatch):
+    mock_log = mock.Mock()
+    monkeypatch.setattr("libgitlab.hookenv.log", mock_log)
+    return mock_log
+
+
+@pytest.fixture
+def libgitlab(
+    tmpdir, mock_hookenv_config, mock_charm_dir, mock_upgrade_package, monkeypatch
+):
     """Mock important aspects of the charm helper library for operation during unit testing."""
     from libgitlab import GitlabHelper
 
@@ -71,6 +112,10 @@ def libgitlab(tmpdir, mock_hookenv_config, mock_charm_dir, monkeypatch):
     with open("./tests/unit/example.cfg", "r") as src_file:
         cfg_file.write(src_file.read())
     gitlab.example_config_file = cfg_file.strpath
+
+    # Mock host functions not appropriate for unit testing
+    gitlab.fetch_gitlab_apt_package = mock.Mock()
+    gitlab.gitlab_reconfigure_run = mock.Mock()
 
     # Any other functions that load the helper will get this version
     monkeypatch.setattr("libgitlab.GitlabHelper", lambda: gitlab)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -34,7 +34,7 @@ def mock_hookenv_config(monkeypatch):
 
     def mock_config():
         cfg = {}
-        yml = yaml.load(open("./config.yaml"))
+        yml = yaml.safe_load(open("./config.yaml"))
 
         # Load all defaults
         for key, value in yml["options"].items():

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -1,4 +1,7 @@
 #!/usr/bin/python3
+
+from mock import call
+
 """Test helper library usage."""
 from charmhelpers.core import unitdata
 
@@ -16,6 +19,71 @@ def test_gitlab(libgitlab):
 def test_gitlab_kv(libgitlab):
     """See if the unitdata kv helper is loaded."""
     assert isinstance(libgitlab.kv, unitdata.Storage)
+
+
+def test_upgrade_gitlab_noop(libgitlab):
+    """ Test the noop path """
+    result = libgitlab.upgrade_gitlab()
+    assert result is False
+
+
+def test_upgrade_gitlab_minor(libgitlab, mock_gitlab_hookenv_log):
+    """ Test the upgrade path """
+    # Upgrade to new minor version
+    libgitlab.get_installed_version.return_value = "1.1.0"
+    result = libgitlab.upgrade_gitlab()
+    print(mock_gitlab_hookenv_log.call_args_list)
+    calls = [
+        call("Processing pending package upgrades for GitLab"),
+        call("Found major version 1 for GitLab version 1.1.1"),
+        call("Found major version 1 for GitLab version 1.1.0"),
+        call("Upgrading GitLab version 1.1.0 to latest in major release 1"),
+    ]
+    mock_gitlab_hookenv_log.assert_has_calls(calls)
+    assert libgitlab.get_installed_version() == "1.1.1"
+    assert result is True
+
+    # Don't upgrade if charm_config matches intalled
+    mock_gitlab_hookenv_log.reset_mock()
+    libgitlab.charm_config["version"] = "1.1.0"
+    libgitlab.get_installed_version.return_value = "1.1.0"
+    result = libgitlab.upgrade_gitlab()
+    assert libgitlab.get_installed_version() == "1.1.0"
+    assert result is False
+
+
+def test_upgrade_gitlab_major(libgitlab, mock_gitlab_hookenv_log):
+    """ Test the upgrade path """
+    libgitlab.get_installed_version.return_value = "0.0.0"
+    result = libgitlab.upgrade_gitlab()
+    print(mock_gitlab_hookenv_log.call_args_list)
+    calls = [
+        call("Processing pending package upgrades for GitLab"),
+        call("Found major version 1 for GitLab version 1.1.1"),
+        call("Found major version 0 for GitLab version 0.0.0"),
+        call("Upgrading GitLab version 0.0.0 to latest in current major release 0"),
+        call("Upgrading GitLab version 0.0.0 to latest in next major release 1"),
+        call("Found major version 1 for GitLab version 1.1.1"),
+        call("Found major version 1 for GitLab version 1.1.1"),
+        call("GitLab is already at configured version 1.1.1"),
+    ]
+    mock_gitlab_hookenv_log.assert_has_calls(calls)
+    assert libgitlab.get_installed_version() == "1.1.1"
+    assert result is True
+
+
+def test_upgrade_gitlab_install(libgitlab, mock_gitlab_hookenv_log):
+    """ Test the upgrade path """
+    libgitlab.get_installed_version.return_value = ""
+    result = libgitlab.upgrade_gitlab()
+    print(mock_gitlab_hookenv_log.call_args_list)
+    calls = [
+        call("Processing pending package upgrades for GitLab"),
+        call("GitLab is not installed, installing..."),
+    ]
+    mock_gitlab_hookenv_log.assert_has_calls(calls)
+    assert libgitlab.get_installed_version() == "1.1.1"
+    assert result is True
 
 
 # Include tests for functions in libgitlab

--- a/tests/unit/test_lib.py
+++ b/tests/unit/test_lib.py
@@ -1,9 +1,8 @@
 #!/usr/bin/python3
-
-from mock import call
-
 """Test helper library usage."""
+
 from charmhelpers.core import unitdata
+from mock import call
 
 
 def test_pytest():
@@ -22,13 +21,13 @@ def test_gitlab_kv(libgitlab):
 
 
 def test_upgrade_gitlab_noop(libgitlab):
-    """ Test the noop path """
+    """Test the noop path."""
     result = libgitlab.upgrade_gitlab()
     assert result is False
 
 
 def test_upgrade_gitlab_minor(libgitlab, mock_gitlab_hookenv_log):
-    """ Test the upgrade path """
+    """Test the upgrade path."""
     # Upgrade to new minor version
     libgitlab.get_installed_version.return_value = "1.1.0"
     result = libgitlab.upgrade_gitlab()
@@ -53,7 +52,7 @@ def test_upgrade_gitlab_minor(libgitlab, mock_gitlab_hookenv_log):
 
 
 def test_upgrade_gitlab_major(libgitlab, mock_gitlab_hookenv_log):
-    """ Test the upgrade path """
+    """Test the upgrade path."""
     libgitlab.get_installed_version.return_value = "0.0.0"
     result = libgitlab.upgrade_gitlab()
     print(mock_gitlab_hookenv_log.call_args_list)
@@ -73,7 +72,7 @@ def test_upgrade_gitlab_major(libgitlab, mock_gitlab_hookenv_log):
 
 
 def test_upgrade_gitlab_install(libgitlab, mock_gitlab_hookenv_log):
-    """ Test the upgrade path """
+    """Test the upgrade path."""
     libgitlab.get_installed_version.return_value = ""
     result = libgitlab.upgrade_gitlab()
     print(mock_gitlab_hookenv_log.call_args_list)

--- a/tox.ini
+++ b/tox.ini
@@ -78,3 +78,5 @@ max-complexity = 10
 [pytest]
 markers =
     deploy: mark deployment tests to allow running w/o redeploy
+filterwarnings = 
+    ignore::DeprecationWarning


### PR DESCRIPTION
Functional tests are failing to install due to an error in upgrade_gitlab on master. This branch adds unit testing for the function, fixes the invalid if statement, and fixes a wrong return value when a major version upgrade is performed. Unit and functional tests are passing now with this branch.